### PR TITLE
Too much boilerplate for the bare-bones stdout-only exercise…

### DIFF
--- a/basic.js
+++ b/basic.js
@@ -1,0 +1,11 @@
+var exercise      = require('./exercise')()
+  , filecheck     = require('./filecheck')
+  , execute       = require('./execute')
+  , comparestdout = require('./comparestdout')
+
+exercise = filecheck(exercise)
+exercise = execute(exercise)
+exercise = comparestdout(exercise)
+
+
+module.exports = exercise

--- a/exercise.js
+++ b/exercise.js
@@ -266,18 +266,5 @@ Exercise.prototype.end = function (mode, pass, callback) {
   })(0)
 }
 
-Exercise.basic = function basicExercise () {
-  var exercise      = new Exercise()
-    , filecheck     = require('./filecheck')
-    , execute       = require('./execute')
-    , comparestdout = require('./comparestdout')
-
-  exercise = filecheck(exercise)
-  exercise = execute(exercise)
-  exercise = comparestdout(exercise)
-
-  return exercise
-}
-
 
 module.exports = Exercise

--- a/exercise.js
+++ b/exercise.js
@@ -266,5 +266,18 @@ Exercise.prototype.end = function (mode, pass, callback) {
   })(0)
 }
 
+Exercise.basic = function basicExercise () {
+  var exercise      = new Exercise()
+    , filecheck     = require('./filecheck')
+    , execute       = require('./execute')
+    , comparestdout = require('./comparestdout')
+
+  exercise = filecheck(exercise)
+  exercise = execute(exercise)
+  exercise = comparestdout(exercise)
+
+  return exercise
+}
+
 
 module.exports = Exercise


### PR DESCRIPTION
Hey Rod,

Say, as I'm migrating workshops based on older `workshopper` versions (0.4.x, 1.x…), I keep having to turn previous "basic case" exercise files that often read as short as this:

```js
module.exports = function () {
  return {}
}
```

Into the "minimum boilerplate" which is this:

```js
var exercise      = require('workshopper-exercise')()
  , filecheck     = require('workshopper-exercise/filecheck')
  , execute       = require('workshopper-exercise/execute')
  , comparestdout = require('workshopper-exercise/comparestdout')

// checks that the submission file actually exists
exercise = filecheck(exercise)

// execute the solution and submission in parallel with spawn()
exercise = execute(exercise)

// compare stdout of solution and submission
exercise = comparestdout(exercise)


module.exports = exercise
```

Woah.  Inflation!

Granted, some of these old-style problems also had to feature a `verify.js` with custom logic, etc. but many did not.

I understand the rationale behind splitting these into separate files and decorators, but the fact of the matter is, a number of non-network-related workshops have most of their exercises that don't need any customization to this, hence their former text as quoted earlier above.

This level of boilerplate reminds me of sad stuff like Jasmine 1.x runner setup, or JDK-style approaches to, say, XSLT transforms that, because they handle once-in-a-millenium cases, force you to spew out dozens of boilerplate lines for the 99% use-case of simple XML String + XSLT String -> String case.

How would you feel about my providing a `.basic()` method on the result of `require('workshopper-exercise'), that would basically do the same as the boilerplate above? (of course, we'd doc it, and test it along with the rest when tests come)

So the bare-bones `exercise.js` file could be as short as:

```js
module.exports = require('workshopper-exercise').basic()
````

Any thoughts?